### PR TITLE
Call constructor of ES6 classes

### DIFF
--- a/src/aggregation-es6.js
+++ b/src/aggregation-es6.js
@@ -34,8 +34,10 @@ var aggregation = (base, ...mixins) => {
 
             /*  call mixin's initializer  */
             mixins.forEach((mixin) => {
-                if (typeof mixin.prototype.initializer === "function")
-                    mixin.prototype.initializer.apply(this, args)
+                if (typeof mixin.prototype.constructor === 'function')
+                    mixin.prototype.constructor.apply(this, args);
+                else if (typeof mixin.prototype.initializer === "function")
+                    mixin.prototype.initializer.apply(this, args)                
             })
         }
     };


### PR DESCRIPTION
ES6 classes has constructor except initializer. Added calling constructor() of ES6 classes.